### PR TITLE
Fix volume not being set to zero

### DIFF
--- a/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/WebsocketPlayer.kt
+++ b/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/WebsocketPlayer.kt
@@ -90,7 +90,7 @@ internal class WebsocketPlayer(internal val node: NodeImpl, internal val guildId
     }
 
     override suspend fun setVolume(volume: Int) {
-        require(volume > 0) { "Volume can't be negative" }
+        require(volume >= 0) { "Volume can't be negative" }
         require(volume <= 1000) { "Volume can't be greater than 1000" }
         this.volume = volume
 

--- a/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/WebsocketPlayer.kt
+++ b/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/internal/WebsocketPlayer.kt
@@ -30,7 +30,12 @@ internal class WebsocketPlayer(internal val node: NodeImpl, internal val guildId
             return lastPosition + elapsedSinceUpdate
         }
 
-    override var volume: Int = 100
+    override var volume: Int
+        @Deprecated("Please use the new filters system to specify volume")
+        set(value) {
+            filters.volume = value / 100f
+        }
+        get() = ((filters.volume ?: 1.0f) * 100).toInt()
 
     @Suppress("unused")
     internal var filters: GatewayPayload.FiltersCommand = GatewayPayload.FiltersCommand(guildId.toString())
@@ -54,8 +59,7 @@ internal class WebsocketPlayer(internal val node: NodeImpl, internal val guildId
         node.send(
             GatewayPayload.PlayCommand(
                 guildId.toString(),
-                track,
-                volume = volume
+                track
             )
         )
     }
@@ -91,10 +95,10 @@ internal class WebsocketPlayer(internal val node: NodeImpl, internal val guildId
 
     override suspend fun setVolume(volume: Int) {
         require(volume >= 0) { "Volume can't be negative" }
-        require(volume <= 1000) { "Volume can't be greater than 1000" }
-        this.volume = volume
+        require(volume <= 500) { "Volume can't be greater than 500" } // Volume <= 5.0
 
-        node.send(GatewayPayload.VolumeCommand(guildId.toString(), volume))
+        filters.volume = volume / 100f
+        node.send(filters)
     }
 
     internal fun provideState(state: GatewayPayload.PlayerUpdateEvent.State) {

--- a/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/player/Player.kt
+++ b/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/player/Player.kt
@@ -78,6 +78,7 @@ public interface Player : EventSource<TrackEvent> {
     /**
      * Changes the volume of the current player.
      */
+    @Deprecated("Please use the new filters system to specify volume")
     public suspend fun setVolume(volume: Int)
 
 }


### PR DESCRIPTION
The library throws an error when setting the volume to zero, and found out that the negative part of the volume sanity check does not include zero. I'm not sure this is an intended part of the operation, but when I updated the code and set the volume to zero, it worked properly without any error.