### PR TITLE
Update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
 # Lavalink.kt
 
-Lavakord is a coroutine based client for [LavaLink](https://github.com/Fredikaram/Lavalink) mainly designed to work
+Lavakord is a coroutine based client for [LavaLink](https://github.com/freyacodes/Lavalink) mainly designed to work
 with [Kord](https://github.com/kordlib/kord)
 
 Support discord: https://discord.gg/ZbmrRVpDwR
 
-**Both Kord and Lavalink.kt is still in an experimental stage, as such we can't guarantee API stability between
+**Both Kord and Lavalink.kt are still in an experimental stage, as such we can't guarantee API stability between
 releases. While we'd love for you to try out our library, we don't recommend you use this in production just yet.**
 
-Lavalink download: [https://github.com/Frederikam/Lavalink](https://github.com/Frederikam/Lavalink#server-configuration)
+Lavalink download: [https://github.com/freyacodes/Lavalink](https://github.com/freyacodes/Lavalink#server-configuration)
 
 # Download
 
-You can get Lavakord from
-here: https://schlaubi.jfrog.io/ui/repos/tree/General/lavakord%2Fdev%2Fschlaubi%2Flavakord
+You can get Lavakord from here: https://search.maven.org/search?q=dev.schlaubi.lavakord
 
 # Usage
 
 You can create a `Lavalink` object like this
 
 ```kotlin
-    val lavalink = kord.lavakord()
+val lavalink = kord.lavakord()
 
 // or    
 
@@ -35,7 +34,7 @@ val lavalink = kord.lavakord {
 You can obtain and use a `Link` like this
 
 ```kotlin
-    val link = guild.getLink(lavalink)
+val link = guild.getLink(lavalink)
 
 link.connect(channel)
 
@@ -44,18 +43,18 @@ link.connect(channel)
 link.disconnect()
 ```
 
-Playing: https://github.com/DRSchlaubi/Lavakord/blob/master/example/src/main/kotlin/me/schlaubi/lavakord/example/Lavakord.kt#L99-124
+Playing: https://github.com/DRSchlaubi/Lavalink.kt/blob/main/example/src/main/kotlin/me/schlaubi/lavakord/example/Lavakord.kt#L82
 
 # Track loading
 
 Lavakord provides a wrapper for the
-Lavalink [Track loading API](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md#track-loading-api)
+Lavalink [Track loading API](https://github.com/freyacodes/Lavalink/blob/master/IMPLEMENTATION.md#track-loading-api)
 
 You can load a Track by using `Link.loadItem(query: String)`
 
 # Events
 
-Since 0.3 Lavakord provides a [Flow based](https://kotlinlang.org/docs/reference/coroutines/flow.html) way to listen for
+Since 0.3 Lavakord provides a [Flow based](https://kotlinlang.org/docs/flow.html) way to listen for
 events.
 
 ```kotlin
@@ -70,7 +69,7 @@ player.on<TrackStartEvent> {
 
 # Documentation
 
-For more info please use the [example](https://github.com/DRSchlaubi/Lavakord/blob/master/example)
+For more info please use the [example](https://github.com/DRSchlaubi/Lavakord/blob/main/example)
 or [Dokka docs](https://l.mik.wtf/)
 
 # Multiplatform
@@ -85,7 +84,7 @@ Since 2.0 JS is officially supported
 
 Since 1.0 it should be possible to implement your own version of lavakord by implementing your own versions of the
 LavaKord and Link classes you can see a reference
-implementation [in the kord package](https://github.com/DRSchlaubi/Lavakord/blob/master/src/main/kotlin/me/schlaubi/lavakord/kord)
+implementation [in the kord package](https://github.com/DRSchlaubi/Lavalink.kt/tree/main/kord/src/jvmMain/kotlin/dev/schlaubi/lavakord/kord)
 
 # Using with Kord
 Add the `kord` artifact


### PR DESCRIPTION
- replaces the old lavalink repo with freya's new username so they can be visited easily
- old /master branch links to the current /main branch
- replace jfrog url with mavencentral search
- a few typos/weird tabs
