### PR TITLE
LinearRetry linearity fix

### DIFF
--- a/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/retry/LinearRetry.kt
+++ b/core/src/commonMain/kotlin/dev/schlaubi/lavakord/audio/retry/LinearRetry.kt
@@ -41,8 +41,11 @@ internal class LinearRetry constructor(
     override suspend fun retry() {
         if (!hasNext) error("max retries exceeded")
 
-        var diff = (maxBackoff - firstBackoff).inWholeMilliseconds / maxTries
-        diff *= tries.incrementAndGet()
+        // tries/maxTries ratio * (backOffDiff) = retryProgress
+        val retryProgress =
+            (tries.incrementAndGet() / maxTries) * (maxBackoff.inWholeMilliseconds - firstBackoff.inWholeMilliseconds)
+        val diff = firstBackoff.inWholeMilliseconds + retryProgress
+
         LOG.info { "retry attempt ${tries.value}/$maxTries, delaying for $diff ms." }
         delay(diff)
     }


### PR DESCRIPTION
The previous formula would not go linearly from minBackoff to maxBackoff and in extreme cases `(e.g minBackoff=2 seconds maxBackoff=Int.MAX_VALUE)` the retry function would delay by `0ms`